### PR TITLE
marktone stops rendering when input is `@` + more than 100 chars

### DIFF
--- a/src/app/markdown/replacer/mention-replacer.ts
+++ b/src/app/markdown/replacer/mention-replacer.ts
@@ -60,6 +60,11 @@ class MentionReplacer {
       const type = matched[1];
       const escapedCode = matched[2];
       const code = MentionReplacer.unescapeCode(escapedCode);
+      // It is needed to skip fetching an organization, a group or a user by code
+      // because kintone returns 520 error when `code` exceeds 100 characters.
+      if (code.length > 100) {
+        continue;
+      }
 
       switch (type) {
         case DirectoryEntityType.ORGANIZATION:


### PR DESCRIPTION
# How to reproduce

Copy & paste this:

```
@aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffffgggggggggghhhhhhhhhhiiiiiiiiiijjjjjjjjjjk

PARAGRAPH1

PARAGRAPH2
```

# Why this is occurred

When inputting `@` + more than 100 chars and sending a HTTP request to kintone search API[0], kintone sends a 520 response and the structure of the response body does not match SearchResponse[1].

So accessing `res.result.users`[2] raises runtime error and rendering stops.

# References
\[0]: https://github.com/ganta/chrome-extension-marktone/blob/84a649f88ee531139c863d2f44c8a606063f67a3/src/app/kintone/kintone-client.ts#L238-L241
\[1]: https://github.com/ganta/chrome-extension-marktone/blob/84a649f88ee531139c863d2f44c8a606063f67a3/src/app/kintone/kintone-client.ts#L31-L37
\[2]: https://github.com/ganta/chrome-extension-marktone/blob/84a649f88ee531139c863d2f44c8a606063f67a3/src/app/kintone/kintone-client.ts#L243