### PR TITLE
marktoneEnabledの判定方法を修正

### DIFF
--- a/src/app/components/marktone.tsx
+++ b/src/app/components/marktone.tsx
@@ -114,7 +114,7 @@ const Marktone = (props: MarktoneProps) => {
 
     if (marktoneEnabled === undefined) return true;
 
-    return !!document.body.dataset.marktoneEnabled;
+    return document.body.dataset.marktoneEnabled === "true";
   };
 
   // Updates the kintone original editor field with the rendered HTML.


### PR DESCRIPTION
marktonの利用可否がfalseのときにdocument.body.dataset.marktoneEnabled が正しく判定されないことで、ピープルの返信時に不要な改行が当たる不具合を修正

不具合内容
marktoneEnabled が false のときに、kintone で「返信」ボタンを押してメンションが挿入されるときに不要なスタイルが当たる（pタグにmargin: 0 0 16pxが当たる）

不具合再現手順
- v1.14.0
- marktonをOFFにする
- kintoneのオリジナルのピープルで誰かの投稿に返信してメンションを挿入する
- メンションを挿入した行で改行する
- pタグにmargin: 0 0 16pxが当たる

![cap](https://user-images.githubusercontent.com/17094072/82619078-e7770180-9c0f-11ea-8a02-1d1ceb7a99b7.png)
