### PR TITLE
Revert "chore: Auto-merge Orbs with Renovate"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,10 +11,6 @@
     {
       "depTypeList": ["devDependencies"],
       "automerge": true
-    },
-    {
-      "managers": ["orb"],
-      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
Reverts ganta/chrome-extension-marktone#132

Orbs is not supported:
```json
{
  "errors": [
    {
      "depName": "Configuration Error",
      "message": "packageRules:\n        You have included an unsupported manager in a package rule. Your list: orb.\n        Supported managers are: (ansible, ansible-galaxy, bazel, buildkite, bundler, cargo, cdnurl, circleci, cocoapods, composer, deps-edn, docker-compose, dockerfile, droneci, git-submodules, github-actions, gitlabci, gitlabci-include, gomod, gradle, gradle-wrapper, helm-requirements, helm-values, helmfile, helmv3, homebrew, html, jenkins, kubernetes, kustomize, leiningen, maven, meteor, mix, nodenv, npm, nuget, nvm, pip_requirements, pip_setup, pipenv, poetry, pub, regex, ruby-version, sbt, swift, terraform, travis)."
    }
  ]
}
```
https://app.renovatebot.com/dashboard#github/ganta/chrome-extension-marktone/217348283
